### PR TITLE
remove duplicate "name" key from service metadata 

### DIFF
--- a/charts/trickster/Chart.yaml
+++ b/charts/trickster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Trickster is an HTTP Reverse Proxy Cache and time series query accelerator.
 name: trickster
-version: 1.5.4
+version: 1.5.5
 home: https://github.com/tricksterproxy/trickster
 icon: https://helm.tricksterproxy.io/img/trickster-horizontal.png
 sources:

--- a/charts/trickster/templates/service.yaml
+++ b/charts/trickster/templates/service.yaml
@@ -12,7 +12,6 @@ metadata:
     prometheus.io/path: /metrics
   {{- end }}
 {{- end }}
-  name: {{ template "trickster.fullname" . }}
   labels:
     app: {{ template "trickster.name" . }}
     {{- include "trickster.labels" . | indent 4 }}


### PR DESCRIPTION
@jranson 
- remove duplicate key which causes issues with kustomize (go-yaml) unmarshal
- bump chart version