### PR TITLE
Update ingress template to work with k8s >=1.19-0

### DIFF
--- a/charts/trickster/Chart.yaml
+++ b/charts/trickster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Trickster is an HTTP Reverse Proxy Cache and time series query accelerator.
 name: trickster
-version: 1.5.5
+version: 1.5.6
 home: https://github.com/tricksterproxy/trickster
 icon: https://helm.tricksterproxy.io/img/trickster-horizontal.png
 sources:

--- a/charts/trickster/templates/ingress.yaml
+++ b/charts/trickster/templates/ingress.yaml
@@ -2,7 +2,18 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "trickster.fullname" . }}
 {{- $servicePort := .Values.service.servicePort -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: trickster-ingress
@@ -17,6 +28,9 @@ metadata:
     {{ $key }}: {{ $value }}
 {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     {{- $url := splitList "/" . }}
@@ -24,9 +38,19 @@ spec:
       http:
         paths:
           - path: /{{ rest $url | join "/" }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+              {{- end }}
   {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/trickster/values.yaml
+++ b/charts/trickster/values.yaml
@@ -567,10 +567,13 @@ ingress:
   ##
   enabled: false
 
+  ## Ingress resource class
+  ##
+  className: ""
+
   ## trickster Ingress annotations
   ##
   annotations: {}
-  #   kubernetes.io/ingress.class: nginx
   #   kubernetes.io/tls-acme: 'true'
 
   ## trickster Ingress additional labels


### PR DESCRIPTION
Tested with k8s-1.24.1 and ingress-nginx controller v1.2.1

Not sure, is it "version:" update in Chart.yaml needed in such PR?