### PR TITLE
feat: support deployment of arbitrary containers

### DIFF
--- a/charts/trickster/templates/deployment.yaml
+++ b/charts/trickster/templates/deployment.yaml
@@ -101,6 +101,9 @@ spec:
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with .Values.additionalContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - name: cfg-volume
         configMap:

--- a/charts/trickster/values.yaml
+++ b/charts/trickster/values.yaml
@@ -255,6 +255,16 @@ prometheusOperator:
     labels: {}
     annotations: {}
 
+# Configure extra containers to deploy with Trickster. Contents should be a list of extra container specifications.
+additionalContainers: []
+# - name: foo
+#   image: busybox
+#   command: ["/bin/sh", "-c"]
+#   args: ["echo hello world"]
+#   volumeMounts:
+#   securityContext:
+#   ...
+
 # Extra resources to deploy with chart
 extra: []
   # - |


### PR DESCRIPTION
Allow configuration of additional containers, along with trickster.

It is not uncommon to need a usage-specific container e.g. service mesh (istio, tailscale etc) or something custom.